### PR TITLE
fix: add StartPlyer Checkbox

### DIFF
--- a/src/main/java/controller/MenuController.java
+++ b/src/main/java/controller/MenuController.java
@@ -60,6 +60,9 @@ public class MenuController {
 	@FXML
 	private JFXCheckBox showHandCheck;
 
+	@FXML 
+	private JFXCheckBox showStartPlayerCheck;
+
 	@FXML
 	private Stage stage;
 
@@ -111,7 +114,7 @@ public class MenuController {
 				options.setRigHandChecked(rigHandCheck.isSelected());
 				options.setRigTileDrawChecked(rigTileCheck.isSelected());
 				options.setShowHandsChecked(showHandCheck.isSelected());
-				options.setShowStartDialog(true);
+				options.setShowStartDialog(showStartPlayerCheck.isSelected());
 
 				logger.debug("OUTPUTTING OPTIONS STRUCTURE");
 				logger.debug("NUM OF PLAYERS IS " + options.getNumPlayers());

--- a/src/main/resources/view/MenuView.fxml
+++ b/src/main/resources/view/MenuView.fxml
@@ -33,6 +33,7 @@
 				<JFXCheckBox text="Set Tile To Draw" fx:id="rigTileCheck"/>
 				<JFXCheckBox text="Set Initial Hands" fx:id="rigHandCheck"/>
 				<JFXCheckBox text="Show All Players' Hand" fx:id="showHandCheck"/>
+				<JFXCheckBox text="Determine Starting Player With Tile Draw" fx:id="showStartPlayerCheck"/>
 				<JFXButton fx:id="btnFileHandRig" text="Rig Hands Using File" />
 				<JFXButton fx:id="exitBtn" text="Exit Game" />
 			</children>


### PR DESCRIPTION
Added a checkbox to allow the user to choose if the starting player was 1 or determined by drawn tiles.